### PR TITLE
Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# ENIGMA
+
+Self-assessment:
+* Functionality
+* Object Oriented Programming
+* Ruby Conventions and Mechanics
+* Test Driven Development
+* Version Control

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Self-assessment:
 * Object Oriented Programming
   * 3.5: Inheritance is implemented wherein Enigma inherits from Rotor, and while it makes sense to me that it be thus, I'm not confident in that particular implementation. There's probably a better name for the class than "Rotor", but I was thinking of the physical Enigma machine and its design.
 * Ruby Conventions and Mechanics
-  * 3.5: Rubocop was a constant companion of mine throughout this project, and oh boy do they have opinions about ruby conventions. I believe that the most efficient enumerables were chosen, at least to the best of my knowledge.
+  * 3.5: Rubocop was a constant companion of mine throughout this project, and oh boy do they have opinions about ruby conventions. I believe that , to the best of my knowledge, the most efficient enumerables were chosen.
 * Test Driven Development
   * 3.5+: Mocks and Stubs have been implemented in two places; the first to stub out the `today` function in my testing to that the test would continue to pass even after the date has changed and so that the testing does not rely upon the functionality of the Date class. The other place it was implemented was in the test for the `crack` method, wherein the `force_key` method has been stubbed out because it has already been tested on its own and would slow the overall test speed down were it not stubbed out. However, I couldn't stub out the `rand` method used in the generation of the key, and I feel that's something I should be able to do.
 * Version Control

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 Self-assessment:
 * Functionality
+  * 4: Crack feature is fully implemented. I'd like to go back at some point and figure out a more elegant solution than the one I came up with, but it works.
 * Object Oriented Programming
+  * 3.5: Inheritance is implemented wherein Enigma inherits from Rotor, and while it makes sense to me that it be thus, I'm not confident in that particular implementation. There's probably a better name for the class than "Rotor", but I was thinking of the physical Enigma machine and its design.
 * Ruby Conventions and Mechanics
+  * 3.5: Rubocop was a constant companion of mine throughout this project, and oh boy do they have opinions about ruby conventions. I believe that the most efficient enumerables were chosen, at least to the best of my knowledge.
 * Test Driven Development
+  * 3.5+: Mocks and Stubs have been implemented in two places; the first to stub out the `today` function in my testing to that the test would continue to pass even after the date has changed and so that the testing does not rely upon the functionality of the Date class. The other place it was implemented was in the test for the `crack` method, wherein the `force_key` method has been stubbed out because it has already been tested on its own and would slow the overall test speed down were it not stubbed out. However, I couldn't stub out the `rand` method used in the generation of the key, and I feel that's something I should be able to do.
 * Version Control
+  * 4: Definitely more than 40 commits (111 at the moment of writing this). Pull Requests contain a short list of the features or methods added, and commits do not contain multiple pieces of functionality (although some contain minor typo corrections.)

--- a/decrypted.txt
+++ b/decrypted.txt
@@ -1,1 +1,1 @@
-hello, world!
+hello this is the worlds end

--- a/encrypted.txt
+++ b/encrypted.txt
@@ -1,1 +1,1 @@
-nfsrua notgoya nkacuxmkyffuj
+oxibvsqypkxzzsqylsteydaigxku

--- a/lib/crack.rb
+++ b/lib/crack.rb
@@ -2,20 +2,15 @@
 
 require './lib/enigma'
 
-arguments = ARGV
-encrypted_filename = arguments[0]
-file_to_write = arguments[1]
-date = arguments[2]
-
-encrypted_message = File.open(encrypted_filename, 'r')
+encrypted_message = File.open(ARGV[0], 'r')
 encrypted_text = encrypted_message.read
 encrypted_message.close
 
 enigma = Enigma.new
 
-decoded = enigma.crack(encrypted_text, date)
-decrypted_file = File.open(file_to_write, 'w')
+decoded = enigma.crack(encrypted_text, ARGV[2])
+decrypted_file = File.open(ARGV[1], 'w')
 decrypted_file.write(decoded[:decryption])
 decrypted_file.close
 
-puts "Created '#{file_to_write}' with the cracked key #{decoded[:key]} and date #{decoded[:date]}"
+puts "Created '#{ARGV[0]}' with the cracked key #{decoded[:key]} and date #{decoded[:date]}"

--- a/lib/crack.rb
+++ b/lib/crack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require './lib/enigma'
 
 arguments = ARGV
@@ -5,7 +7,7 @@ encrypted_filename = arguments[0]
 file_to_write = arguments[1]
 date = arguments[2]
 
-encrypted_message = File.open(encrypted_filename, "r")
+encrypted_message = File.open(encrypted_filename, 'r')
 encrypted_text = encrypted_message.read
 encrypted_message.close
 

--- a/lib/crack.rb
+++ b/lib/crack.rb
@@ -4,6 +4,7 @@ arguments = ARGV
 encrypted_filename = arguments[0]
 file_to_write = arguments[1]
 date = arguments[2]
+
 encrypted_message = File.open(encrypted_filename, "r")
 encrypted_text = encrypted_message.read
 encrypted_message.close
@@ -15,4 +16,4 @@ decrypted_file = File.open(file_to_write, 'w')
 decrypted_file.write(decoded[:decryption])
 decrypted_file.close
 
-puts "Created '#{file_to_write}' with the key #{decoded[:key]} and date #{decoded[:date]}"
+puts "Created '#{file_to_write}' with the cracked key #{decoded[:key]} and date #{decoded[:date]}"

--- a/lib/decrypt.rb
+++ b/lib/decrypt.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require './lib/enigma'
 
 ARGV
 
-encrypted_message = File.open(ARGV[0], "r")
+encrypted_message = File.open(ARGV[0], 'r')
 encrypted_text = encrypted_message.read
 encrypted_message.close
 

--- a/lib/decrypt.rb
+++ b/lib/decrypt.rb
@@ -2,8 +2,6 @@
 
 require './lib/enigma'
 
-ARGV
-
 encrypted_message = File.open(ARGV[0], 'r')
 encrypted_text = encrypted_message.read
 encrypted_message.close

--- a/lib/encrypt.rb
+++ b/lib/encrypt.rb
@@ -2,9 +2,6 @@
 
 require './lib/enigma'
 
-# ARGV saves additional arguments given from command line as an array
-ARGV
-
 message = File.open(ARGV[0], 'r')
 text = message.read
 message.close

--- a/lib/encrypt.rb
+++ b/lib/encrypt.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require './lib/enigma'
 
 # ARGV saves additional arguments given from command line as an array
 ARGV
 
-message = File.open(ARGV[0], "r")
+message = File.open(ARGV[0], 'r')
 text = message.read
 message.close
 

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -8,17 +8,13 @@ class Enigma < Rotor
   end
 
   def encrypt(message, digits = @key_gen.key_digits, date = @key_gen.todays_date)
-    key = @key_gen.make_key(digits)
-    offsets = @key_gen.make_offsets(date.delete('/'))
-    shifts = @key_gen.generate_shifts(key, offsets)
+    shifts = @key_gen.parse_inputs(digits, date)
     encoded = shift_letters(message, shifts)
     { encryption: encoded, key: digits, date: date.delete('/') }
   end
 
   def decrypt(message, digits, date = @key_gen.todays_date)
-    key = @key_gen.make_key(digits)
-    offsets = @key_gen.make_offsets(date.delete('/'))
-    shifts = @key_gen.generate_shifts(key, offsets)
+    shifts = @key_gen.parse_inputs(digits, date)
     decoded = shift_letters(message, shifts, 'backwards')
     { decryption: decoded, key: digits, date: date.delete('/') }
   end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -30,8 +30,8 @@ class Enigma < Rotor
       @alphabet.index(character) - @alphabet.index(known_characters[char_index])
     end
     decoded = shift_letters(message.reverse, shifts, 'backwards').reverse
-    encrypted = force_key(decoded, message, date)
-    { decryption: decoded, date: date, key: encrypted[:key] }
+    cracked_key = force_key(decoded, message, date)
+    { decryption: decoded, date: date, key: cracked_key }
   end
 
   def force_key(decrypted_msg, encrypted_msg, date)
@@ -41,6 +41,6 @@ class Enigma < Rotor
       number = number.next
       encrypted = encrypt(decrypted_msg, number, date)
     end
-    encrypted
+    encrypted[:key]
   end
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -9,14 +9,14 @@ class Enigma < Rotor
 
   def encrypt(message, digits = @key_gen.key_digits, date = @key_gen.todays_date)
     shifts = @key_gen.parse_inputs(digits, date)
-    encoded = shift_letters(message, shifts)
-    { encryption: encoded, key: digits, date: date.delete('/') }
+    encoded_message = shift_letters(message, shifts)
+    { encryption: encoded_message, key: digits, date: date.delete('/') }
   end
 
   def decrypt(message, digits, date = @key_gen.todays_date)
     shifts = @key_gen.parse_inputs(digits, date)
-    decoded = shift_letters(message, shifts, 'backwards')
-    { decryption: decoded, key: digits, date: date.delete('/') }
+    decoded_message = shift_letters(message, shifts, 'backwards')
+    { decryption: decoded_message, key: digits, date: date.delete('/') }
   end
 
   def crack(message, date = @key_gen.todays_date)

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -4,6 +4,7 @@ require './lib/rotor'
 
 class Enigma < Rotor
   def initialize
+    super()
     @key_gen = KeyGenerator.new
   end
 
@@ -24,11 +25,10 @@ class Enigma < Rotor
   end
 
   def crack(message, date = todays_date)
-    alphabet = ('a'..'z').to_a << ' '
     known_characters = ['d', 'n', 'e', ' ']
     actual_characters = message.split('')[-4..-1].reverse
     shifts = actual_characters.map.with_index do |character, char_index|
-      alphabet.index(character) - alphabet.index(known_characters[char_index])
+      @alphabet.index(character) - @alphabet.index(known_characters[char_index])
     end
     decoded = shift_letters(message.reverse, shifts, 'backwards').reverse
     encrypted = force_key(decoded, message, date)

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 require './lib/key_generator'
 require './lib/rotor'
 
+# Contains logic for how characters are to be shifted
 class Enigma < Rotor
   def initialize
     super()
@@ -31,7 +34,7 @@ class Enigma < Rotor
   end
 
   def force_key(decrypted_msg, encrypted_msg, date)
-    number = "00000"
+    number = '00000'
     encrypted = encrypt(decrypted_msg, number, date)
     until encrypted[:encryption] == encrypted_msg
       number = number.next

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,4 +1,3 @@
-require 'Date'
 require './lib/key_generator'
 require './lib/rotor'
 

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -13,7 +13,7 @@ class Enigma < Rotor
     offsets = @key_gen.make_offsets(date.delete('/'))
     shifts = @key_gen.generate_shifts(key, offsets)
     encoded = shift_letters(message, shifts)
-    { encryption: encoded, key: digits, date: date }
+    { encryption: encoded, key: digits, date: date.delete('/') }
   end
 
   def decrypt(message, digits, date = @key_gen.todays_date)
@@ -21,7 +21,7 @@ class Enigma < Rotor
     offsets = @key_gen.make_offsets(date.delete('/'))
     shifts = @key_gen.generate_shifts(key, offsets)
     decoded = shift_letters(message, shifts, 'backwards')
-    { decryption: decoded, key: digits, date: date }
+    { decryption: decoded, key: digits, date: date.delete('/') }
   end
 
   def crack(message, date = @key_gen.todays_date)

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -10,21 +10,21 @@ class Enigma < Rotor
 
   def encrypt(message, digits = @key_gen.key_digits, date = @key_gen.todays_date)
     key = @key_gen.make_key(digits)
-    offsets = @key_gen.make_offsets(date)
+    offsets = @key_gen.make_offsets(date.delete('/'))
     shifts = @key_gen.generate_shifts(key, offsets)
     encoded = shift_letters(message, shifts)
     { encryption: encoded, key: digits, date: date }
   end
 
-  def decrypt(message, digits, date = todays_date)
+  def decrypt(message, digits, date = @key_gen.todays_date)
     key = @key_gen.make_key(digits)
-    offsets = @key_gen.make_offsets(date)
+    offsets = @key_gen.make_offsets(date.delete('/'))
     shifts = @key_gen.generate_shifts(key, offsets)
     decoded = shift_letters(message, shifts, 'backwards')
     { decryption: decoded, key: digits, date: date }
   end
 
-  def crack(message, date = todays_date)
+  def crack(message, date = @key_gen.todays_date)
     known_characters = ['d', 'n', 'e', ' ']
     actual_characters = message.split('')[-4..-1].reverse
     shifts = actual_characters.map.with_index do |character, char_index|

--- a/lib/key_generator.rb
+++ b/lib/key_generator.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 require 'Date'
 
+# In charge of all methods pertaining to generating shifts
 class KeyGenerator
   def todays_date
     Date.today.strftime('%d%m%y')
@@ -22,7 +25,7 @@ class KeyGenerator
   def generate_shifts(key, offsets)
     key.zip(offsets).map(&:sum)
   end
-  
+
   def parse_inputs(digits, date)
     key = make_key(digits)
     offsets = make_offsets(date.delete('/'))

--- a/lib/key_generator.rb
+++ b/lib/key_generator.rb
@@ -27,8 +27,6 @@ class KeyGenerator
   end
 
   def parse_inputs(digits, date)
-    key = make_key(digits)
-    offsets = make_offsets(date.delete('/'))
-    generate_shifts(key, offsets)
+    generate_shifts(make_key(digits), make_offsets(date.delete('/')))
   end
 end

--- a/lib/key_generator.rb
+++ b/lib/key_generator.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'Date'
-
 # In charge of all methods pertaining to generating shifts
 class KeyGenerator
   def todays_date

--- a/lib/key_generator.rb
+++ b/lib/key_generator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'date'
+
 # In charge of all methods pertaining to generating shifts
 class KeyGenerator
   def todays_date

--- a/lib/key_generator.rb
+++ b/lib/key_generator.rb
@@ -22,4 +22,10 @@ class KeyGenerator
   def generate_shifts(key, offsets)
     key.zip(offsets).map(&:sum)
   end
+  
+  def parse_inputs(digits, date)
+    key = make_key(digits)
+    offsets = make_offsets(date.delete('/'))
+    generate_shifts(key, offsets)
+  end
 end

--- a/lib/rotor.rb
+++ b/lib/rotor.rb
@@ -1,11 +1,14 @@
 class Rotor
+  def initialize
+    @alphabet = ('a'..'z').to_a << ' '
+  end
+
   def shift_letters(message, shifts, default = 'forward')
-    alphabet = ('a'..'z').to_a << ' '
     shifts = shifts.map(&:-@) if default != 'forward'
     split_message = message.downcase.split('')
     split_message.map.with_index do |character, char_index|
-      if alphabet.include?(character)
-        alphabet.rotate(shifts[char_index % 4])[alphabet.index(character)]
+      if @alphabet.include?(character)
+        @alphabet.rotate(shifts[char_index % 4])[@alphabet.index(character)]
       else
         character
       end

--- a/lib/rotor.rb
+++ b/lib/rotor.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# Shifts letters to new locations
 class Rotor
   def initialize
     @alphabet = ('a'..'z').to_a << ' '

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -18,7 +18,7 @@ class EnigmaTest < MiniTest::Test
       key: '02715',
       date: '040895'
     }
-    assert_equal expected, @enigma.encrypt('HELLO WORLD!', '02715', '040895')
+    assert_equal expected, @enigma.encrypt('HELLO WORLD!', '02715', '04/08/95')
   end
 
   def test_it_can_decrypt_text_with_given_parameters
@@ -27,7 +27,7 @@ class EnigmaTest < MiniTest::Test
       key: '02715',
       date: '040895'
     }
-    assert_equal expected, @enigma.decrypt('keder ohulw!', '02715', '040895')
+    assert_equal expected, @enigma.decrypt('keder ohulw!', '02715', '04/08/95')
   end
 
   def test_it_can_crack_text_with_given_date
@@ -39,12 +39,6 @@ class EnigmaTest < MiniTest::Test
     assert_equal expected, @enigma.crack('vjqtbeaweqihssi', '291018')
   end
 
-  def test_it_can_shift_letters
-    shifts = [3, 27, 73, 20]
-    assert_equal 'keder ohulw!', @enigma.shift_letters('HELLO WORLD!', shifts)
-    assert_equal 'hello world!', @enigma.shift_letters('keder ohulw!', shifts, 'backwards')
-  end
-  
   def test_it_can_brute_force_key
     encrypted = @enigma.force_key('hello world end', 'vjqtbeaweqihssi', '291018')
     assert_equal '08304', encrypted[:key]

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -31,6 +31,7 @@ class EnigmaTest < MiniTest::Test
   end
 
   def test_it_can_crack_text_with_given_date
+    @enigma.stubs(:force_key).returns('08304')
     expected = {
       decryption: 'hello world end',
       date: '291018',
@@ -40,7 +41,7 @@ class EnigmaTest < MiniTest::Test
   end
 
   def test_it_can_brute_force_key
-    encrypted = @enigma.force_key('hello world end', 'vjqtbeaweqihssi', '291018')
-    assert_equal '08304', encrypted[:key]
+    cracked_key = @enigma.force_key('hello world end', 'vjqtbeaweqihssi', '291018')
+    assert_equal '08304', cracked_key
   end
 end

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require './test/test_helper'
 require 'mocha/minitest'
 

--- a/test/key_generator_test.rb
+++ b/test/key_generator_test.rb
@@ -37,4 +37,8 @@ class KeyGeneratorTest < MiniTest::Test
     offsets = [1, 0, 2, 5]
     assert_equal [3, 27, 73, 20], @key_generator.generate_shifts(keys, offsets)
   end
+
+  def test_can_parse_date_and_key_into_shifts
+    assert_equal [3, 27, 73, 20], @key_generator.parse_inputs('24680', '040895')
+  end
 end

--- a/test/key_generator_test.rb
+++ b/test/key_generator_test.rb
@@ -39,6 +39,6 @@ class KeyGeneratorTest < MiniTest::Test
   end
 
   def test_can_parse_date_and_key_into_shifts
-    assert_equal [3, 27, 73, 20], @key_generator.parse_inputs('24680', '040895')
+    assert_equal [3, 27, 73, 20], @key_generator.parse_inputs('02715', '040895')
   end
 end

--- a/test/key_generator_test.rb
+++ b/test/key_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require './test/test_helper'
 
 require './lib/key_generator'

--- a/test/rotor_test.rb
+++ b/test/rotor_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require './test/test_helper'
 
 require './lib/rotor'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'simplecov'
 SimpleCov.start
 


### PR DESCRIPTION
VARIOUS IMPROVEMENTS TO EXISTING CODE
- Refactor Key Generator to reduce key creation size in Enigma methods
- Use `super` in Enigma to access Rotor's alphabet
- Change date handling to account for slashes
- Do most of the things that rubocop recommends
- Create README and write self assessment
- Change Key Generator's requiring of "Date" to "date" to fix rake's warning messages

- [ ] Come back someday and rework `crack` to be less Dumb™